### PR TITLE
RC 11.1.2

### DIFF
--- a/Setup.org
+++ b/Setup.org
@@ -77,6 +77,9 @@ SOFTWARE.
 
 * Publishing
 
+Documentation can be published with ~M-x org-publish-project~.
+This will also tangle this setup-file which contain all the styles etc
+for the documentation-page.
 #+name: publishing
 #+begin_src emacs-lisp
 (unless (boundp 'org-publish-project-alist)
@@ -704,6 +707,8 @@ a {
 
 ** Actions
 
+We observe the code-blocks to see when it's in the viewport. When a
+code-block is visible, the code associated will be initialized.
 #+begin_src javascript :tangle docs/js/docs.js
 const main = (w, d) => {
     const examples = [].slice.call(d.querySelectorAll('[data-src]'));

--- a/index.org
+++ b/index.org
@@ -351,7 +351,7 @@ reagent state-handling.
 #+html: </div>
 
 
-** Examples manifests                                                 :noexport:
+** Manifests                                                           :noexport:
 
 *** Deps.edn
 #+begin_src clojure :tangle babel/examples/deps.edn


### PR DESCRIPTION
This is the first release candidate of ReagentFlow, but we adopted the version-scheme of ReactFlow to make it easier to follow the relevant documentation etc.

There are hooks for CI, CD and publishing of documentation, so one should just use git per usual.
- Pull requests that are accepted into `main` will have CI run tests.
- Tags created from `main` will be released & github pages will be updated with the latest documentation.

Tags must use the same scheme as ReactFlow versions.